### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,11 +40,11 @@ export default {
     }
   },
 
-  activate: () => {
+  activate() {
     require("atom-package-deps").install("linter-emscripten");
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const helpers = require("atom-linter");
     const clangFlags = require("clang-flags");
     const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+):(\{(?<lineStart>\\d+):(?<colStart>\\d+)\-(?<lineEnd>\\d+):(?<colEnd>\\d+)}.*:)? (?<type>[\\w \\-]+): (?<message>.*)";


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.